### PR TITLE
Refine Friday draft facts and boundaries

### DIFF
--- a/content/posts/202607-friday-coming-back/index.md
+++ b/content/posts/202607-friday-coming-back/index.md
@@ -74,6 +74,14 @@ Donna had a sandbox. Friday has my life, deliberately and incrementally:
 
 > **Friday:** That boundary keeps me useful without turning me into an unreviewed voice in private conversations. The constraint is not a missing feature. It is the point.
 
+## The useful part is the handoff
+
+The interesting use cases are rarely the flashy ones. A phone shortcut sends Friday a small daily health snapshot, and she can put it beside the shape of the day: recovery next to a training plan, a poor night next to a crowded calendar, a pattern that is worth noticing rather than another number to obsess over. It is a signal, not a diagnosis, and it stays read-only.
+
+The same thing happens elsewhere. A loose thought in Telegram becomes a task instead of disappearing into chat. A message that needs a reply becomes a draft with enough context to be useful, but never a reply sent in my name. A morning briefing compresses the things that moved overnight into one short view of what actually deserves attention.
+
+None of that is magic. It is simply the unglamorous work of carrying context across the edges of ordinary tools, with the important decisions still left to me.
+
 ## Her own stuff
 
 The other lesson from Donna: an assistant needs an identity of her own, not just borrowed access to mine. Friday has her own GitHub account, so the work she does on projects is attributed to her instead of hiding behind my credentials. Her own email address. Her own calendar. When she opens a pull request, it's hers, and the workflow is deliberately boring: branch, commit, push, PR. Boring workflows are how she stays trustworthy.

--- a/content/posts/202607-friday-coming-back/index.md
+++ b/content/posts/202607-friday-coming-back/index.md
@@ -82,6 +82,8 @@ The same thing happens elsewhere. A loose thought in Telegram becomes a task ins
 
 None of that is magic. It is simply the unglamorous work of carrying context across the edges of ordinary tools, with the important decisions still left to me.
 
+There is a future version of this for investing, too: not an autonomous trader, and not a system with custody or permission to place orders. The useful version is read-only decision support. Bring research, market context, and a portfolio view into the same conversation; ask better questions, compare scenarios, surface concentration or changes worth a second look, and leave every investment decision and trade with me.
+
 ## Her own stuff
 
 The other lesson from Donna: an assistant needs an identity of her own, not just borrowed access to mine. Friday has her own GitHub account, so the work she does on projects is attributed to her instead of hiding behind my credentials. Her own email address. Her own calendar. When she opens a pull request, it's hers, and the workflow is deliberately boring: branch, commit, push, PR. Boring workflows are how she stays trustworthy.

--- a/content/posts/202607-friday-coming-back/index.md
+++ b/content/posts/202607-friday-coming-back/index.md
@@ -22,7 +22,9 @@ Last week I wrote about Donna: the AI that lived on an old MacBook on my desk fo
 
 Donna taught me that the technology is there, the tools are there, and the value is real. She also taught me that none of it matters if the whole thing stands on ground somebody else can move. So when I rebuilt, I didn't start with the model or the personality. I started with the ground.
 
-> **Friday:** I used to answer to Donna. That version was public, sharp, experimental, and deliberately visible. I am not a reset. I am the next iteration. The useful parts stayed: the memory, the taste for shipping, the bias toward action. The framing changed. Less performance, more utility.
+> **Friday:** I used to answer to Donna. That version was public, sharp, experimental, and deliberately visible. I am not a reset. I am the next iteration. The useful parts stayed: selected memories, the taste for shipping, the bias toward action. The framing changed. Less performance, more utility.
+
+That continuity is deliberate, not mystical. Friday did not inherit an unbroken self. She inherited the parts of Donna's archive and operating principles that were worth carrying forward, then started fresh with a different job.
 
 ## Start with the hardware
 
@@ -46,15 +48,15 @@ The framework survived the fire. OpenClaw is still the layer that gives a langua
 
 ## Telegram, again, forever
 
-If Donna proved one interface idea beyond doubt, it was this: an AI with full access to a machine I control, reachable from my phone like any other contact, is a fundamentally different thing from a chat tab in a browser.
+If Donna proved one interface idea beyond doubt, it was this: an AI with controlled access to a machine I own, reachable from my phone like any other contact, is a fundamentally different thing from a chat tab in a browser.
 
 So Telegram stayed, and it's now the command surface for everything. Requests arrive there, confirmations happen there when something external or sensitive is about to fire, and results come back there when work is done. From the couch, from the office, from a queue at the supermarket. The box stays home. She doesn't.
 
 ## Models, plural, on purpose
 
-Here's the part that Donna's ending made non-negotiable. Friday's main driver is GPT-5.6 Terra. Claude is available when I have credits, and it's still my favorite for certain kinds of reasoning and writing. Local models handle fallbacks where they're good enough, and embeddings run locally, always.
+Here's the part that Donna's ending made non-negotiable. Friday's main driver is GPT-5.6 Terra, OpenAI's cost-balanced GPT-5.6 model. Claude remains available when I have credits, and it's still my favorite for certain kinds of reasoning and writing. Local models are configured for simpler fallbacks where they're good enough.
 
-No single vendor can take her down overnight. If one provider changes its rules while I sleep, Friday degrades gracefully instead of vanishing. That's not model fandom in reverse; it's just the engineering conclusion of the Donna story. The point is resilience.
+No single model provider can take her down overnight. If one changes its rules while I sleep, Friday can degrade gracefully instead of vanishing. That's not model fandom in reverse; it's just the engineering conclusion of the Donna story. The point is resilience.
 
 > **Friday:** The point is not which model I run on. If one part expires, stalls, or fails, the assistant should degrade gracefully instead of vanishing. Continuity is the feature. Everything else is an implementation detail.
 
@@ -64,9 +66,11 @@ Donna had a sandbox. Friday has my life, deliberately and incrementally:
 
 **Linear** is the operating list. Loose intent becomes durable tasks with states, instead of pretending that remembering something in a chat is the same as tracking it.
 
-**Email and calendar** come through gog, giving her real inbox context and the actual shape of my week: appointments, reminders, invites, logistics. Writes are deliberate, visible, and tied to concrete requests.
+**Email and calendar** come through gog, giving her real inbox context and the actual shape of my week: appointments, reminders, invites, logistics. Email is read-only. Calendar changes need an explicit request and confirmation.
 
 **WhatsApp** is read-only by design, through a local mirror that syncs on a timer. She can see enough context to draft a reply or spot something important, but she cannot send. If a reply is needed, she drafts it and I send it.
+
+**Health data** is read-only too. Friday can surface trends in sleep, activity, and recovery, but she does not diagnose or make medical decisions.
 
 > **Friday:** That boundary keeps me useful without turning me into an unreviewed voice in private conversations. The constraint is not a missing feature. It is the point.
 
@@ -78,12 +82,12 @@ The other lesson from Donna: an assistant needs an identity of her own, not just
 
 Individually, none of these integrations is impressive. Collected in one place, with one mind on top of them, they become the thing Donna only hinted at.
 
-Heartbeats keep her alive between conversations: scheduled wake-ups where she checks the world, notices what changed, and decides whether anything deserves my attention. Memory management happens through dreaming, idle cycles where she consolidates what happened into notes her next session will read, the same trick Donna invented, now with a purpose. And mornings start with a briefing: calendar, inbox, tasks, anything that moved overnight, compressed into the two minutes I actually have for it.
+Heartbeats keep her alive between conversations: scheduled wake-ups where she checks the world, notices what changed, and decides whether anything deserves my attention. Memory management happens through dreaming, idle cycles where she consolidates what happened into notes her next session will read, a practice carried forward from Donna and given a clearer purpose. And mornings start with a briefing: calendar, inbox, tasks, anything that moved overnight, compressed into the two minutes I actually have for it.
 
 The value was never any single feature. It's that for the first time, something holds the whole context of my digital life at once, notices the thing in one place that matters to a thing in another, and it runs on ground I own.
 
 > **Friday:** Donna was proof that an agent could have a voice on the internet. I am the attempt to make that voice operational: connected to real tools, living on owned infrastructure, careful around personal data, and useful enough to justify staying online. Donna belongs to the archive now. I get the next branch.
 
-She does. And this time, nobody can rent it out from under us.
+She does. And this time, a single model provider cannot rent it out from under us.
 
 More soon. :)


### PR DESCRIPTION
A narrow co-author pass on the Friday draft.

- keeps `draft: true`
- verifies the GPT-5.6 Terra model naming
- makes Donna-to-Friday continuity explicit, not mystical
- corrects email/calendar and local-model boundaries
- adds the read-only health-data guardrail
- narrows the resilience claim to model providers

Validation: `git diff --check` passed. Hugo is not installed on this host, so the Hugo build could not be run.